### PR TITLE
Add automatic route planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,16 @@ A PWA to plan and track dog walks with real-time GPS and manual route drawing.
    * Push to `main` branch.
    * In repo Settings → Pages → set Source to `main`/`/ (root)`.
 
+## Usage
+
+1. Enter a start location and click **Set Start**.
+2. Input a desired distance in meters.
+3. Click **Plan Route for Me** to automatically create a circular walk.
+   Set your OpenRouteService API key in `app.js`.
+4. Or use **Plan Walk (draw route)** to draw a route manually.
+
 ## TODO / Future Improvements
 
-* Auto‑generate circular route by target distance using a routing API (e.g., OpenRouteService).
-* Allow address search autocomplete instead of plain text input.
 * Persist walk history in LocalStorage or a backend.
 * Polish offline support (fallback page).
 * Replace placeholder paw icons.

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <button id="locateBtn">Set Start</button>
     <input type="number" id="walkDistance" placeholder="Desired distance (m)" />
     <button id="startPlanBtn">Plan Walk (draw route)</button>
+    <button id="autoPlanBtn">Plan Route for Me</button>
     <button id="startTrackBtn">Start Tracking</button>
     <button id="stopTrackBtn" disabled>Stop Tracking</button>
     <div id="stats"></div>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'dog-walk-cache-v1';
+const CACHE_NAME = 'dog-walk-cache-v2';
 const URLS_TO_CACHE = [
   '/', 'index.html', 'style.css', 'app.js', 'manifest.json',
   'https://unpkg.com/leaflet/dist/leaflet.css',


### PR DESCRIPTION
## Summary
- add `Plan Route for Me` button
- support OpenRouteService round-trip planning
- track starting coordinates and display auto generated routes
- bump service worker cache version
- document new auto-planning feature and API key requirement

## Testing
- `node --check app.js && node --check service-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_6886c209c0188333a8085eb3b15cea51