### PR TITLE
Add Clear Walk button and functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ A PWA to plan and track dog walks with real-time GPS and manual route drawing.
 4. Click **Plan Route for Me** to automatically create a circular walk.
    Set your OpenRouteService API key in `app.js`.
 5. Or use **Plan Walk (draw route)** to draw a route manually.
+6. Click **Start Tracking** to record your walk in real time. Use **Stop Tracking** to end recording.
+7. Use **Clear Walk** to remove any planned or tracked route and reset the stats.
 
 ## TODO / Future Improvements
 

--- a/app.js
+++ b/app.js
@@ -141,6 +141,27 @@ document.getElementById('stopTrackBtn').addEventListener('click', () => {
   document.getElementById('stopTrackBtn').disabled = true;
 });
 
+// Clear current walk data and map overlays
+document.getElementById('clearWalkBtn').addEventListener('click', () => {
+  if (plannedRoute) {
+    drawnItems.removeLayer(plannedRoute);
+    plannedRoute = null;
+  }
+  if (trackLine) {
+    map.removeLayer(trackLine);
+    trackLine = null;
+  }
+  plannedDistance = 0;
+  trackDistance = 0;
+  trackLatLngs = [];
+  if (watchId) {
+    navigator.geolocation.clearWatch(watchId);
+    watchId = null;
+  }
+  document.getElementById('stopTrackBtn').disabled = true;
+  updateStats();
+});
+
 // Called on each GPS update
 function onPosition(pos) {
   const latlng = [pos.coords.latitude, pos.coords.longitude];

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
     <button id="autoPlanBtn">Plan Route for Me</button>
     <button id="startTrackBtn">Start Tracking</button>
     <button id="stopTrackBtn" disabled>Stop Tracking</button>
+    <button id="clearWalkBtn">Clear Walk</button>
     <div id="stats"></div>
   </div>
   <div id="map"></div>


### PR DESCRIPTION
## Summary
- add Clear Walk button
- implement Clear Walk handler to remove existing routes, reset stats, and stop geolocation
- document Clear Walk button in README

## Testing
- `python3 -m py_compile setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6886cf6bdeb483338e7de6045ac105fc