### PR TITLE
Add walk preference control

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ A PWA to plan and track dog walks with real-time GPS and manual route drawing.
 2. Enter a start location and click **Set Start** if you want to override the
    detected location.
 3. Input a desired distance and select your preferred unit.
-4. Click **Plan Route for Me** to automatically create a circular walk.
+4. Choose a **Walk Preference**:
+   * **Scenic** – generates a longer, more varied loop.
+   * **Shortest** – aims for the quickest route back to the start.
+5. Click **Plan Route for Me** to automatically create a circular walk.
    Set your OpenRouteService API key in `app.js`.
-5. Or use **Plan Walk (draw route)** to draw a route manually.
+6. Or use **Plan Walk (draw route)** to draw a route manually.
 
 ## TODO / Future Improvements
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
       <option value="feet">ft</option>
       <option value="yards">yd</option>
     </select>
+    <select id="walkPreference">
+      <option value="scenic">Scenic</option>
+      <option value="shortest">Shortest</option>
+    </select>
     <button id="startPlanBtn">Plan Walk (draw route)</button>
     <button id="autoPlanBtn">Plan Route for Me</button>
     <button id="startTrackBtn">Start Tracking</button>


### PR DESCRIPTION
## Summary
- add walk preference dropdown to control panel
- store selected preference and show in stats
- pass preference through automatic planning
- document preferences in README

## Testing
- `python3 -m py_compile setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6886cf6dac0483339d4d34cc0226bbc9