### PR TITLE
Center controls and add extra walk actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ A PWA to plan and track dog walks with real-time GPS and manual route drawing.
    **Shortest** preference is selected fewer turn points are used for a more
    direct loop.
 7. Or use **Plan Walk (draw route)** to draw a route manually.
-8. Click **Start Tracking** to record your walk in real time. Use **Stop Tracking** to end recording.
-9. Use **Clear Walk** to remove any planned or tracked route and reset the stats.
+8. Click **Start Tracking** to record your walk in real time. Use **Pause** and **Resume** to temporarily stop or continue tracking. Use **Stop Tracking** to finish recording.
+9. Click **Save Walk** to store the tracked route. Use **Load Walk** to display the last saved route.
+10. Use **Clear Walk** to remove any planned or tracked route and reset the stats.
 
 ## TODO / Future Improvements
 

--- a/app.js
+++ b/app.js
@@ -138,6 +138,9 @@ document.getElementById('startTrackBtn').addEventListener('click', () => {
   if (trackLine) map.removeLayer(trackLine);
   trackLine = L.polyline([], { color: '#A0522D' }).addTo(map);
   document.getElementById('stopTrackBtn').disabled = false;
+  document.getElementById('pauseTrackBtn').disabled = false;
+  document.getElementById('resumeTrackBtn').disabled = true;
+  document.getElementById('saveWalkBtn').disabled = true;
   watchId = navigator.geolocation.watchPosition(onPosition, err => console.error(err), {
     enableHighAccuracy: true,
     maximumAge: 1000,
@@ -149,6 +152,51 @@ document.getElementById('startTrackBtn').addEventListener('click', () => {
 document.getElementById('stopTrackBtn').addEventListener('click', () => {
   if (watchId) navigator.geolocation.clearWatch(watchId);
   document.getElementById('stopTrackBtn').disabled = true;
+  document.getElementById('pauseTrackBtn').disabled = true;
+  document.getElementById('resumeTrackBtn').disabled = true;
+  document.getElementById('saveWalkBtn').disabled = false;
+});
+
+// Pause tracking without clearing the line
+document.getElementById('pauseTrackBtn').addEventListener('click', () => {
+  if (watchId) {
+    navigator.geolocation.clearWatch(watchId);
+    watchId = null;
+    document.getElementById('pauseTrackBtn').disabled = true;
+    document.getElementById('resumeTrackBtn').disabled = false;
+  }
+});
+
+// Resume tracking after a pause
+document.getElementById('resumeTrackBtn').addEventListener('click', () => {
+  if (!navigator.geolocation || watchId) return;
+  watchId = navigator.geolocation.watchPosition(onPosition, err => console.error(err), {
+    enableHighAccuracy: true,
+    maximumAge: 1000,
+    timeout: 10000
+  });
+  document.getElementById('pauseTrackBtn').disabled = false;
+  document.getElementById('resumeTrackBtn').disabled = true;
+});
+
+// Save the most recent track to localStorage
+document.getElementById('saveWalkBtn').addEventListener('click', () => {
+  if (trackLatLngs.length) {
+    localStorage.setItem('lastWalk', JSON.stringify(trackLatLngs));
+    alert('Walk saved');
+  } else {
+    alert('No walk to save');
+  }
+});
+
+// Load the last saved walk from localStorage
+document.getElementById('loadWalkBtn').addEventListener('click', () => {
+  const data = localStorage.getItem('lastWalk');
+  if (!data) return alert('No saved walk');
+  const coords = JSON.parse(data);
+  if (trackLine) map.removeLayer(trackLine);
+  trackLine = L.polyline(coords, { color: '#A0522D' }).addTo(map);
+  map.fitBounds(trackLine.getBounds());
 });
 
 // Clear current walk data and map overlays
@@ -169,6 +217,9 @@ document.getElementById('clearWalkBtn').addEventListener('click', () => {
     watchId = null;
   }
   document.getElementById('stopTrackBtn').disabled = true;
+  document.getElementById('pauseTrackBtn').disabled = true;
+  document.getElementById('resumeTrackBtn').disabled = true;
+  document.getElementById('saveWalkBtn').disabled = true;
   updateStats();
 });
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,11 @@
     <button id="startPlanBtn">Plan Walk (draw route)</button>
     <button id="autoPlanBtn">Plan Route for Me</button>
     <button id="startTrackBtn">Start Tracking</button>
+    <button id="pauseTrackBtn" disabled>Pause</button>
+    <button id="resumeTrackBtn" disabled>Resume</button>
     <button id="stopTrackBtn" disabled>Stop Tracking</button>
+    <button id="saveWalkBtn" disabled>Save Walk</button>
+    <button id="loadWalkBtn">Load Walk</button>
     <button id="clearWalkBtn">Clear Walk</button>
     <div id="stats"></div>
   </div>

--- a/style.css
+++ b/style.css
@@ -6,12 +6,18 @@ body { font-family: 'Baloo 2', sans-serif; }
 
 /* Control panel styling */
 #controls {
-  position:absolute;
-  top:10px; left:10px; right:10px;
-  background: rgba(210,180,140,0.9);  /* tan */
-  padding:10px; border-radius:8px;
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(210,180,140,0.9); /* tan */
+  padding: 10px;
+  border-radius: 8px;
   font-family: 'Baloo 2', sans-serif;
-  z-index:1000;
+  z-index: 1000;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 #controls input, #controls button, #controls select {
   margin:4px; padding:8px;


### PR DESCRIPTION
## Summary
- make control panel use flexbox and center it at the top
- add Pause, Resume, Save Walk, and Load Walk buttons
- support new actions in `app.js`
- mention new options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d53307bc833392d05dbba00f676e