### PR TITLE
Add collapsible mobile menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A PWA to plan and track dog walks with real-time GPS and manual route drawing.
 8. Click **Start Tracking** to record your walk in real time. A pulsating dot shows your current location while tracking. Use **Pause** and **Resume** to temporarily stop or continue tracking. Use **Stop Tracking** to finish recording.
 9. Click **Save Walk** to store the tracked route. Use **Load Walk** to display the last saved route.
 10. Use **Clear Walk** to remove any planned or tracked route and reset the stats.
+11. On small screens tap the **☰** button to show or hide the controls.
 
 ## TODO / Future Improvements
 

--- a/app.js
+++ b/app.js
@@ -383,3 +383,8 @@ async function autoPlanRoute(start, targetMeters, preference) {
 }
 
 // Auto-planning now available using OpenRouteService
+
+// Mobile menu toggle
+document.getElementById('menuToggle').addEventListener('click', () => {
+  document.getElementById('controls').classList.toggle('hidden');
+});

--- a/index.html
+++ b/index.html
@@ -11,7 +11,8 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div id="controls">
+  <button id="menuToggle" aria-label="Toggle menu">☰</button>
+  <div id="controls" class="hidden">
     <input type="text" id="startLocation" placeholder="Enter start address or lat,lng" />
     <button id="locateBtn">Set Start</button>
     <input type="number" id="walkDistance" placeholder="Desired distance" />

--- a/style.css
+++ b/style.css
@@ -81,6 +81,39 @@ body { font-family: 'Baloo 2', sans-serif; }
   color: #4B2E05;
 }
 
+/* Toggle button for mobile menu */
+#menuToggle {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: #A0522D;
+  color: white;
+  border: none;
+  padding: 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  z-index: 1100;
+  display: none; /* hidden on larger screens */
+}
+
+#controls.hidden {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  #menuToggle {
+    display: block;
+  }
+  #controls {
+    top: 50px;
+    right: 10px;
+    left: auto;
+    width: 80%;
+    max-width: 300px;
+    max-height: calc(100% - 60px);
+  }
+}
+
 /* Pulsating indicator for live tracking */
 .tracking-indicator {
   width: 16px;


### PR DESCRIPTION
## Summary
- add toggle button for controls on small screens
- hide controls behind a menu button on mobile
- document the mobile menu in README

## Testing
- `python3 -m py_compile setup.py`

------
https://chatgpt.com/codex/tasks/task_e_688786701d708333a2b0efe2414cadc4