### PR TITLE
Add live distance overlay

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ let trackLatLngs = [];
 let watchId = null;
 let startCoords = null;
 let trackingIndicator = null;
+const distanceOverlay = document.getElementById('distanceOverlay');
 let walkPreference = 'scenic';
 let autoRoutes = [];
 let autoRouteIndex = -1;
@@ -201,6 +202,10 @@ document.getElementById('startTrackBtn').addEventListener('click', () => {
     map.removeLayer(trackingIndicator);
     trackingIndicator = null;
   }
+  if (distanceOverlay) {
+    distanceOverlay.classList.remove('hidden');
+    distanceOverlay.textContent = '';
+  }
   document.getElementById('stopTrackBtn').disabled = false;
   document.getElementById('pauseTrackBtn').disabled = false;
   document.getElementById('resumeTrackBtn').disabled = true;
@@ -219,6 +224,7 @@ document.getElementById('stopTrackBtn').addEventListener('click', () => {
     map.removeLayer(trackingIndicator);
     trackingIndicator = null;
   }
+  if (distanceOverlay) distanceOverlay.classList.add('hidden');
   document.getElementById('stopTrackBtn').disabled = true;
   document.getElementById('pauseTrackBtn').disabled = true;
   document.getElementById('resumeTrackBtn').disabled = true;
@@ -281,6 +287,7 @@ document.getElementById('clearWalkBtn').addEventListener('click', () => {
     map.removeLayer(trackingIndicator);
     trackingIndicator = null;
   }
+  if (distanceOverlay) distanceOverlay.classList.add('hidden');
   plannedDistance = 0;
   trackDistance = 0;
   trackLatLngs = [];
@@ -331,6 +338,9 @@ function updateStats() {
     txt += ` | Pref: ${walkPreference}`;
   }
   document.getElementById('stats').textContent = txt;
+  if (distanceOverlay && !distanceOverlay.classList.contains('hidden')) {
+    distanceOverlay.textContent = `${tracked} ${unit}`;
+  }
 }
 
 // Generate a circular route automatically

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
     </select>
   </div>
   <div id="map"></div>
+  <div id="distanceOverlay" class="hidden"></div>
 
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet-draw/dist/leaflet.draw.js"></script>

--- a/style.css
+++ b/style.css
@@ -100,6 +100,10 @@ body { font-family: 'Baloo 2', sans-serif; }
   display: none;
 }
 
+.hidden {
+  display: none;
+}
+
 @media (max-width: 600px) {
   #menuToggle {
     display: block;
@@ -122,6 +126,19 @@ body { font-family: 'Baloo 2', sans-serif; }
   border-radius: 50%;
   box-shadow: 0 0 0 rgba(160, 82, 45, 0.7);
   animation: pulse 1s infinite;
+}
+
+#distanceOverlay {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-weight: bold;
+  z-index: 1200;
 }
 
 @keyframes pulse {


### PR DESCRIPTION
## Summary
- show hidden floating distance overlay while tracking a walk
- style the new overlay and general hidden class

## Testing
- `python3 -m py_compile setup.py`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6888ad755df88333810096bfbef508b2