### PR TITLE
Refine mobile menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ A PWA to plan and track dog walks with real-time GPS and manual route drawing.
    * **Scenic** – generates a longer, more varied loop.
    * **Shortest** – aims for the quickest route back to the start.
 5. Copy `config.js.example` to `config.js` and add your OpenRouteService API key.
-6. Click **Plan Route for Me** to automatically create a circular walk. The
+6. Click **Auto Plan** to automatically create a circular walk. The
    generated route tries to stick to streets and avoid narrow alleys. When the
    **Shortest** preference is selected fewer turn points are used for a more
    direct loop.
-7. Or use **Plan Walk (draw route)** to draw a route manually.
-8. Click **Start Tracking** to record your walk in real time. A pulsating dot shows your current location while tracking. The app now requests a screen wake lock so the phone doesn't automatically sleep during tracking. Use **Pause** and **Resume** to temporarily stop or continue tracking. Use **Stop Tracking** to finish recording.
-9. Click **Save Walk** to store the tracked route. Use **Load Walk** to display the last saved route.
-10. Use **Clear Walk** to remove any planned or tracked route and reset the stats.
+7. Or use **Draw Route** to sketch a walk manually.
+8. Click **Start** to record your walk in real time. A pulsating dot shows your current location while tracking. The app now requests a screen wake lock so the phone doesn't automatically sleep during tracking. Use **Pause** and **Resume** to temporarily stop or continue tracking. Use **Stop** to finish recording.
+9. Click **Save** to store the tracked route. Use **Load** to display the last saved route.
+10. Use **Clear** to remove any planned or tracked route and reset the stats.
 11. On small screens tap the **☰** button to show or hide the controls.
 
 ## TODO / Future Improvements

--- a/index.html
+++ b/index.html
@@ -27,17 +27,17 @@
       <option value="scenic">Scenic</option>
       <option value="shortest">Shortest</option>
     </select>
-    <button id="startPlanBtn">Plan Walk (draw route)</button>
-    <button id="autoPlanBtn">Plan Route for Me</button>
+    <button id="startPlanBtn">Draw Route</button>
+    <button id="autoPlanBtn">Auto Plan</button>
     <button id="prevRouteBtn" disabled>&lt;</button>
     <button id="nextRouteBtn" disabled>&gt;</button>
-    <button id="startTrackBtn">Start Tracking</button>
+    <button id="startTrackBtn">Start</button>
     <button id="pauseTrackBtn" disabled>Pause</button>
     <button id="resumeTrackBtn" disabled>Resume</button>
-    <button id="stopTrackBtn" disabled>Stop Tracking</button>
-    <button id="saveWalkBtn" disabled>Save Walk</button>
-    <button id="loadWalkBtn">Load Walk</button>
-    <button id="clearWalkBtn">Clear Walk</button>
+    <button id="stopTrackBtn" disabled>Stop</button>
+    <button id="saveWalkBtn" disabled>Save</button>
+    <button id="loadWalkBtn">Load</button>
+    <button id="clearWalkBtn">Clear</button>
     <div id="stats"></div>
   </div>
   <div id="basemapControls">

--- a/style.css
+++ b/style.css
@@ -7,21 +7,21 @@ body { font-family: 'Baloo 2', sans-serif; }
 /* Control panel styling */
 #controls {
   position: absolute;
-  top: 10px;
+  bottom: 60px;
+  left: 10px;
   right: 10px;
-  left: auto;
   transform: none;
   background: rgba(210,180,140,0.9); /* tan */
   padding: 10px;
   border-radius: 8px;
   font-family: 'Baloo 2', sans-serif;
   z-index: 1000;
-  width: 250px;
+  width: calc(100% - 20px);
   display: flex;
   flex-direction: column;
   align-items: stretch;
   overflow-y: auto;
-  max-height: calc(100% - 20px);
+  max-height: calc(60% - 20px);
 }
 #controls input,
 #controls button,
@@ -84,7 +84,7 @@ body { font-family: 'Baloo 2', sans-serif; }
 /* Toggle button for mobile menu */
 #menuToggle {
   position: absolute;
-  top: 10px;
+  bottom: 10px;
   right: 10px;
   background: #A0522D;
   color: white;
@@ -93,7 +93,7 @@ body { font-family: 'Baloo 2', sans-serif; }
   border-radius: 4px;
   cursor: pointer;
   z-index: 1100;
-  display: none; /* hidden on larger screens */
+  display: block;
 }
 
 #controls.hidden {
@@ -104,24 +104,25 @@ body { font-family: 'Baloo 2', sans-serif; }
   display: none;
 }
 
-@media (max-width: 600px) {
+@media (min-width: 600px) {
   #menuToggle {
-    display: block;
+    display: none;
   }
   #controls {
-    top: 50px;
+    top: 10px;
     right: 10px;
     left: auto;
-    width: 80%;
-    max-width: 300px;
-    max-height: calc(100% - 60px);
+    bottom: auto;
+    width: 250px;
+    max-width: none;
+    max-height: calc(100% - 20px);
   }
   #distanceOverlay {
-    width: 100%;
-    left: 0;
-    transform: none;
+    width: auto;
+    left: 50%;
+    transform: translateX(-50%);
     text-align: center;
-    font-size: 1.25em;
+    font-size: 1.1em;
   }
 }
 


### PR DESCRIPTION
## Summary
- shorten menu button text
- reposition controls for mobile-first layout
- add desktop styles via media query
- update README instructions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68897640ee988333b3c7b8d9871c724b