### PR TITLE
Display walk distance overlay at bottom

### DIFF
--- a/style.css
+++ b/style.css
@@ -121,6 +121,7 @@ body { font-family: 'Baloo 2', sans-serif; }
     width: auto;
     left: 50%;
     transform: translateX(-50%);
+    bottom: 10px;
     text-align: center;
     font-size: 1.1em;
   }
@@ -138,7 +139,7 @@ body { font-family: 'Baloo 2', sans-serif; }
 
 #distanceOverlay {
   position: fixed;
-  top: 10px;
+  bottom: 10px;
   left: 50%;
   transform: translateX(-50%);
   background: rgba(0, 0, 0, 0.6);


### PR DESCRIPTION
## Summary
- move `#distanceOverlay` to the bottom of the viewport
- keep the overlay positioned at the bottom on larger screens

## Testing
- `python3 -m py_compile setup.py`

------
https://chatgpt.com/codex/tasks/task_e_688978d277ac8333ae05a1c23fb0f9a2